### PR TITLE
Bump commons-io from 2.6 to 2.7 in /MyStoreProject

### DIFF
--- a/MyStoreProject/pom.xml
+++ b/MyStoreProject/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>